### PR TITLE
feat(media): Use metadata for Drive files and fix auth token refresh

### DIFF
--- a/app/api/upload-media/route.ts
+++ b/app/api/upload-media/route.ts
@@ -11,37 +11,6 @@ async function fileToBuffer(file: File): Promise<Buffer> {
   return Buffer.from(arrayBuffer);
 }
 
-// This helper function finds or creates a folder and returns its ID.
-async function findOrCreateFolder(
-  drive: drive_v3.Drive,
-  folderName: string,
-  parentId: string
-): Promise<string> {
-  // Check if folder already exists
-  const query = `'${parentId}' in parents and name='${folderName}' and mimeType='application/vnd.google-apps.folder' and trashed=false`;
-  const { data } = await drive.files.list({
-    q: query,
-    fields: 'files(id)',
-    spaces: 'drive',
-  });
-
-  if (data.files && data.files.length > 0) {
-    return data.files[0].id!;
-  }
-
-  // If not, create it
-  const folderMetadata = {
-    name: folderName,
-    mimeType: 'application/vnd.google-apps.folder',
-    parents: [parentId],
-  };
-  const folder = await drive.files.create({
-    requestBody: folderMetadata,
-    fields: 'id',
-  });
-  return folder.data.id!;
-}
-
 export async function POST(request: Request) {
   try {
     const { auth, googleDriveFolderId } = await getAuthenticatedClient();
@@ -57,32 +26,23 @@ export async function POST(request: Request) {
     
     const file = formData.get('file') as File;
     const journeyId = formData.get('journeyId') as string;
-    const journeyDate = new Date(formData.get('journeyDate') as string);
     
     // Basic validations
     if (!file) return NextResponse.json({ error: 'No file provided' }, { status: 400 });
     if (!isValidMediaType(file.type)) return NextResponse.json({ error: 'Invalid file type.' }, { status: 400 });
     if (file.size > MAX_FILE_SIZE) return NextResponse.json({ error: 'File too large.' }, { status: 400 });
-    if (!journeyId || !journeyDate) return NextResponse.json({ error: 'Missing journey information' }, { status: 400 });
+    if (!journeyId) return NextResponse.json({ error: 'Missing journey information' }, { status: 400 });
 
-    // 1. Define folder structure
-    const year = journeyDate.getFullYear().toString();
-    const month = (journeyDate.getMonth() + 1).toString().padStart(2, '0');
-    const mediaType = file.type.startsWith('image/') ? 'images' : 'videos';
-
-    // 2. Create folder hierarchy sequentially
-    const yearFolderId = await findOrCreateFolder(drive, year, googleDriveFolderId);
-    const monthFolderId = await findOrCreateFolder(drive, month, yearFolderId);
-    const journeyFolderId = await findOrCreateFolder(drive, journeyId, monthFolderId);
-    const mediaTypeFolderId = await findOrCreateFolder(drive, mediaType, journeyFolderId);
-    
-    // 3. Upload the file
+    // 1. Upload the file with metadata
     const fileBuffer = await fileToBuffer(file);
     const fileStream = Readable.from(fileBuffer);
     
     const fileMetadata = {
       name: file.name,
-      parents: [mediaTypeFolderId],
+      parents: [googleDriveFolderId],
+      appProperties: {
+        journeyId: journeyId,
+      },
     };
     
     const media = {
@@ -96,20 +56,12 @@ export async function POST(request: Request) {
       fields: 'id, webViewLink, webContentLink',
     });
     
-    // 4. Get the public URL for the folder
-    const folderDetails = await drive.files.get({
-        fileId: journeyFolderId,
-        fields: 'webViewLink'
-    });
-    const folderLink = folderDetails.data.webViewLink;
-
-    logger.info('Upload completed successfully', { fileId: response.data.id, path: mediaTypeFolderId });
+    logger.info('Upload completed successfully with metadata', { fileId: response.data.id, journeyId: journeyId });
 
     return NextResponse.json({
       success: true,
       fileId: response.data.id,
       webViewLink: response.data.webViewLink,
-      folderLink: folderLink,
       mediaType: file.type.startsWith('image/') ? 'image' : 'video'
     });
 

--- a/lib/google-api-client.ts
+++ b/lib/google-api-client.ts
@@ -2,6 +2,7 @@ import { AuthOptions, getServerSession } from "next-auth";
 import { google } from "googleapis";
 import { db } from "./db";
 import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import { logger } from "@/lib/logger";
 
 /**
  * A centralized service for creating authenticated Google API clients
@@ -26,10 +27,12 @@ interface AuthenticatedClientResponse {
 export async function getAuthenticatedClient(): Promise<AuthenticatedClientResponse> {
   const session = await getServerSession(authOptions);
   if (!session?.user?.id) {
+    logger.error("getAuthenticatedClient: No session or user ID found.");
     throw new Error("User not authenticated or session is missing user ID.");
   }
 
   const userId = session.user.id;
+  logger.info(`getAuthenticatedClient: Authenticating user ID: ${userId}`);
 
   // 1. Fetch user's OAuth tokens from the 'accounts' table
   const accountQuery = await db.query(
@@ -38,13 +41,16 @@ export async function getAuthenticatedClient(): Promise<AuthenticatedClientRespo
   );
 
   if (accountQuery.rows.length === 0) {
+    logger.error(`getAuthenticatedClient: No Google account found for user ID: ${userId}`);
     throw new Error(`No Google account found for user ID: ${userId}`);
   }
 
   const { access_token, refresh_token } = accountQuery.rows[0];
+  logger.info(`getAuthenticatedClient: Fetched tokens from DB. Has access_token: ${!!access_token}, Has refresh_token: ${!!refresh_token}`);
 
   if (!refresh_token) {
     // This is a critical issue. The user might need to re-authenticate.
+    logger.error(`getAuthenticatedClient: Missing refresh token for user ID: ${userId}`);
     throw new Error(`Missing refresh token for user ID: ${userId}. Please re-authenticate.`);
   }
   
@@ -57,6 +63,7 @@ export async function getAuthenticatedClient(): Promise<AuthenticatedClientRespo
   // It's okay if the user has no config yet, so we don't throw an error here.
   const userConfig = configQuery.rows[0] || {};
   const { googleSheetsId, googleDriveFolderId } = userConfig;
+  logger.debug(`getAuthenticatedClient: User config found`, { userId, hasSheet: !!googleSheetsId, hasDrive: !!googleDriveFolderId });
 
   // 3. Create and configure the Google OAuth2 client
   const auth = new google.auth.OAuth2({
@@ -68,6 +75,20 @@ export async function getAuthenticatedClient(): Promise<AuthenticatedClientRespo
     access_token: access_token,
     refresh_token: refresh_token,
   });
+
+  try {
+    // Force a token refresh to ensure the access_token is valid.
+    const { token } = await auth.getAccessToken();
+    if (token) {
+      auth.setCredentials({ access_token: token });
+      logger.info(`getAuthenticatedClient: Successfully refreshed access token for user ID: ${userId}`);
+    } else {
+      logger.warn(`getAuthenticatedClient: Access token refresh did not return a new token for user ID: ${userId}`);
+    }
+  } catch (error) {
+    logger.error('getAuthenticatedClient: Failed to refresh access token.', { userId, error });
+    throw new Error('Could not refresh access token. Please try re-authenticating.');
+  }
 
   // The googleapis library will automatically handle refreshing the access_token
   // if it's expired, as long as a valid refresh_token is provided.


### PR DESCRIPTION
Refactors Google Drive integration to be metadata-driven. Media uploads now attach a `journeyId` as an `appProperty` instead of creating nested folders. The `get-media` endpoint now uses a single, efficient query based on this metadata.

Fixes persistent "401 Invalid Credentials" errors by forcing an update of the user's OAuth tokens in the database on every sign-in via the NextAuth `signIn` callback. This ensures credentials are always fresh.