### PR TITLE
feat: Configurable Map Zoom Distance with Enhanced Auth UX

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,22 +86,40 @@ useEffect(() => {
 - `components/ClientProviders.tsx` - Client-side provider wrapper
 - `components/ui/location-autocomplete.tsx` - Location search component
 
+#### Authentication System
+- NextAuth.js with Google OAuth using database sessions (30-day expiry)
+- Custom secure token management prevents account conflation
+- Comprehensive authentication logging via `lib/auth-logger.ts`
+- OAuth scope validation ensures required Google permissions
+- Session stored in PostgreSQL with automatic token refresh
+
+#### Database Migrations
+- PostgreSQL migrations in `/database/migrations/`
+- Current migration: `add-unit-preferences.sql` for units system
+- Use `psql -d database_url -f migration_file.sql` for manual migration
+
 ## Development Guidelines
 
-### Code Patterns
-- Use TypeScript strict mode
-- Follow existing component patterns from Shadcn/UI
-- Implement proper error boundaries for API calls
-- Use React Hook Form with Zod validation for forms
+### Critical Patterns
+- **React 18 Strict Mode**: Avoid react-leaflet library - use manual Leaflet instance management
+- **Context Isolation**: Wrap client providers in `ClientProviders.tsx` to prevent ChunkLoadError
+- **Form Validation**: Use React Hook Form with Zod validation for all forms
+- **Error Boundaries**: Implement proper error boundaries for all API calls
 
 ### API Design
-- RESTful endpoints with proper HTTP methods
-- Consistent error handling and logging
-- Rate limiting for external APIs (especially Nominatim)
-- Session-based authentication validation
+- RESTful endpoints with proper HTTP methods and error handling
+- Session-based authentication validation using NextAuth
+- Rate limiting for external APIs (especially Nominatim geocoding)
+- Comprehensive request/response logging with `authLogger`
+
+### Environment Variables Required
+- `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` - OAuth credentials
+- `DATABASE_URL` - Neon PostgreSQL connection string
+- `NEXTAUTH_URL` / `NEXTAUTH_SECRET` - NextAuth configuration
+- `SMTP_*` - Email configuration (optional)
 
 ### Performance Considerations
-- Client-side caching for geocoding results
-- Debounced user inputs for API calls
-- Optimized image handling for media uploads
+- Client-side geocoding cache with LRU implementation
+- Debounced user inputs for API calls (especially location search)
+- Image optimization disabled for better compatibility
 - Efficient database queries with proper indexing

--- a/components/maps/WorldMap.tsx
+++ b/components/maps/WorldMap.tsx
@@ -5,6 +5,8 @@ import L, { Map, Marker } from 'leaflet';
 import { Button } from '@/components/ui/button';
 import { X } from 'lucide-react';
 import 'leaflet/dist/leaflet.css';
+import { useUnits } from '@/lib/UnitsContext';
+import { distanceToZoomLevel } from '@/lib/unit-conversions';
 
 interface LocationInfo {
   city: string;
@@ -92,6 +94,9 @@ const WorldMap = ({ onLocationSelect, mode = 'single', onJourneySelect }: WorldM
   const [isLoading, setIsLoading] = useState(false);
   const [lastLocation, setLastLocation] = useState<LastLocation | null>(null);
   const [isLoadingLastLocation, setIsLoadingLastLocation] = useState(true);
+  
+  // Get user's unit preferences for map zoom distance
+  const { unitPreferences } = useUnits();
   
   // Journey mode state
   const [journeyState, setJourneyState] = useState<JourneyState>({
@@ -205,8 +210,9 @@ const WorldMap = ({ onLocationSelect, mode = 'single', onJourneySelect }: WorldM
       
       if (lastLocation) {
         initialCenter = [lastLocation.lat, lastLocation.lng];
-        // Zoom level 8 shows approximately 100-mile radius
-        initialZoom = 8;
+        // Use user's preferred zoom distance (stored in km, convert to zoom level)
+        const zoomDistanceKm = unitPreferences.mapZoomDistance || 100;
+        initialZoom = distanceToZoomLevel(zoomDistanceKm);
       }
       
       mapInstanceRef.current = L.map(mapContainerRef.current).setView(initialCenter, initialZoom);

--- a/database/migrations/add-map-zoom-preference.sql
+++ b/database/migrations/add-map-zoom-preference.sql
@@ -1,0 +1,24 @@
+-- Add map zoom distance preference to user_google_config table
+-- This allows users to customize the default zoom distance when viewing maps
+
+ALTER TABLE user_google_config 
+ADD COLUMN IF NOT EXISTS "mapZoomDistance" INTEGER DEFAULT 100;
+
+-- Add check constraint to ensure reasonable zoom distance values (5-500 km/miles)
+ALTER TABLE user_google_config 
+ADD CONSTRAINT IF NOT EXISTS check_map_zoom_distance 
+CHECK ("mapZoomDistance" >= 5 AND "mapZoomDistance" <= 500);
+
+-- Update the updatedAt timestamp for any existing records
+UPDATE user_google_config 
+SET "updatedAt" = NOW() 
+WHERE "mapZoomDistance" IS NULL;
+
+-- Create index for faster map zoom preference queries (optional, for performance)
+CREATE INDEX IF NOT EXISTS idx_user_google_config_map_zoom 
+ON user_google_config ("mapZoomDistance");
+
+-- Verify the migration
+-- SELECT column_name, data_type, column_default, is_nullable 
+-- FROM information_schema.columns 
+-- WHERE table_name = 'user_google_config' AND column_name = 'mapZoomDistance';

--- a/lib/unit-conversions.ts
+++ b/lib/unit-conversions.ts
@@ -121,6 +121,41 @@ export function calculateDistance(
 }
 
 /**
+ * Convert distance in kilometers to approximate Leaflet zoom level
+ * Based on the relationship between zoom levels and visible radius
+ */
+export function distanceToZoomLevel(distanceKm: number): number {
+  // Approximate zoom levels based on radius in km
+  // These values are calibrated for Leaflet maps
+  if (distanceKm >= 1000) return 3;  // Global/continental view
+  if (distanceKm >= 500) return 4;   // Large country view
+  if (distanceKm >= 250) return 5;   // Country/state view
+  if (distanceKm >= 150) return 6;   // State/region view
+  if (distanceKm >= 100) return 7;   // Large metro area
+  if (distanceKm >= 50) return 8;    // Metro area (default)
+  if (distanceKm >= 25) return 9;    // City view
+  if (distanceKm >= 15) return 10;   // City center
+  if (distanceKm >= 10) return 11;   // Neighborhood
+  if (distanceKm >= 5) return 12;    // Local area
+  return 13; // Very local view
+}
+
+/**
+ * Convert user's preferred zoom distance to display value
+ */
+export function formatZoomDistance(distanceKm: number, unit: DistanceUnit): string {
+  const convertedDistance = convertDistanceFromKm(distanceKm, unit);
+  return formatDistance(convertedDistance, unit, 0);
+}
+
+/**
+ * Convert zoom distance from user's preferred unit to kilometers (for storage)
+ */
+export function convertZoomDistanceToKm(distance: number, fromUnit: DistanceUnit): number {
+  return convertDistanceToKm(distance, fromUnit);
+}
+
+/**
  * Convert journey data to user's preferred units
  */
 export function convertJourneyToUserUnits(

--- a/types/units.ts
+++ b/types/units.ts
@@ -4,6 +4,7 @@ export type DistanceUnit = 'miles' | 'nautical_miles' | 'kilometers';
 export interface UnitPreferences {
   speedUnit: SpeedUnit;
   distanceUnit: DistanceUnit;
+  mapZoomDistance?: number; // Distance in kilometers for map zoom (converted for display)
 }
 
 export interface UnitConfig {
@@ -33,5 +34,6 @@ export const DISTANCE_UNITS: Record<DistanceUnit, { label: string; symbol: strin
 
 export const DEFAULT_UNIT_PREFERENCES: UnitPreferences = {
   speedUnit: 'knots',
-  distanceUnit: 'nautical_miles'
+  distanceUnit: 'nautical_miles',
+  mapZoomDistance: 100 // Default 100km zoom distance
 }; 


### PR DESCRIPTION
## Summary
• **New Feature**: Configurable map zoom distance in Settings with unit-aware conversion
• **Enhanced Auth UX**: Removed forced consent for returning users and extended session lifetime
• **Improved Documentation**: Updated CLAUDE.md with authentication patterns and development guidelines

## Key Features Added

### 🗺️ Configurable Map Zoom Distance
- **User Control**: Set custom zoom distance (5-500 in preferred units) instead of hardcoded 100-mile radius
- **Unit Conversion**: Automatically converts between miles, nautical miles, and kilometers
- **Smart Integration**: Map component dynamically uses user's zoom preference
- **Database Schema**: Added `mapZoomDistance` column with validation constraints

### 🔐 Enhanced Authentication UX  
- **Seamless Re-entry**: Removed forced consent screen for returning Google OAuth users
- **Extended Sessions**: 30-day database sessions with daily refresh cycles
- **Secure Token Management**: Prevents account conflation with improved validation

### 📚 Enhanced Documentation
- **Authentication System**: Documented NextAuth patterns and security measures
- **Development Guidelines**: Added critical patterns for React 18 + Next.js 15
- **Environment Variables**: Complete reference for required configuration

## Database Changes
```sql
-- New column for map zoom preferences
ALTER TABLE user_google_config 
ADD COLUMN "mapZoomDistance" INTEGER DEFAULT 100
CHECK ("mapZoomDistance" >= 5 AND "mapZoomDistance" <= 500);
```

## Test Plan
- [ ] Test new user sign-up flow (should show consent screen once)
- [ ] Test returning user login (should skip consent, go directly to dashboard)
- [ ] Verify 30-day session persistence across browser restarts
- [ ] Test map zoom distance setting in all three units (km/mi/nm)
- [ ] Verify map centers with custom zoom distances (test 10km, 50km, 200km)
- [ ] Confirm unit conversion when switching distance preferences
- [ ] Test map zoom validation (reject values outside 5-500 range)

🤖 Generated with [Claude Code](https://claude.ai/code)